### PR TITLE
Add DownloadSample method

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,1 @@
-module github.com/nbareil/mispgo
+module github.com/simsor/mispgo


### PR DESCRIPTION
Added a Client.DownloadSample() method which downloads a malware sample to a file on the disk.
Needs the attribute ID of the sample.

Also created a test for the method.